### PR TITLE
Revert integration source name

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,7 @@ If you're against adding plugins to your build file, simply copy-paste the confi
 
 ## Migrating from 1.x.x to 2.x.x
 
-- Rename integration test source folder from `src/integration` to `src/integrationTest`.
-- In `build.gradle[.kts]` file in `dependencies {}` section use `integrationTestImplementation(...)` instead of
-  `integrationImplementation(...)`.
 - Skipping flags changed names. Use `skipTests`, `skipUnitTests`, `skipIntegrationTests`
   instead of `skipTest`, `skipUnitTest`, `skipIntegrationTest`.
 - Added integration with Jacoco - coverage from integration tests is automatically included in report.
-- Integration with JUnit4 is removed.
+- Integration with JUnit4 is dropped.

--- a/src/main/kotlin/com/coditory/gradle/integration/IntegrationTestPlugin.kt
+++ b/src/main/kotlin/com/coditory/gradle/integration/IntegrationTestPlugin.kt
@@ -21,6 +21,7 @@ open class IntegrationTestPlugin : Plugin<Project> {
 
     companion object {
         const val PLUGIN_ID = "com.coditory.integration-test"
+        const val INTEGRATION = "integration"
         const val INTEGRATION_TEST = "integrationTest"
         const val TEST_ALL_TASK_NAME = "testAll"
         const val SKIP_UNIT_TEST_FLAG_NAME = "skipUnitTest"

--- a/src/main/kotlin/com/coditory/gradle/integration/JacocoTaskConfiguration.kt
+++ b/src/main/kotlin/com/coditory/gradle/integration/JacocoTaskConfiguration.kt
@@ -1,6 +1,6 @@
 package com.coditory.gradle.integration
 
-import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.INTEGRATION_TEST
+import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.INTEGRATION
 import org.gradle.api.Project
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
@@ -10,17 +10,17 @@ internal object JacocoTaskConfiguration {
     fun apply(project: Project) {
         if (project.pluginManager.hasPlugin("jacoco")) {
             var dstFile: String? = null
-            project.tasks.named(INTEGRATION_TEST) { task ->
+            project.tasks.named(INTEGRATION) { task ->
                 val jacocoTaskExtension = task.extensions.getByType(JacocoTaskExtension::class.java)
                 dstFile = jacocoTaskExtension.destinationFile?.path
             }
             if (dstFile != null) {
                 project.tasks.withType(JacocoReport::class.java) { task ->
                     task.executionData(dstFile)
-                    task.mustRunAfter(INTEGRATION_TEST)
+                    task.mustRunAfter(INTEGRATION)
                 }
                 project.tasks.withType(JacocoCoverageVerification::class.java) { task ->
-                    task.mustRunAfter(INTEGRATION_TEST)
+                    task.mustRunAfter(INTEGRATION)
                 }
             }
         }

--- a/src/main/kotlin/com/coditory/gradle/integration/TestAllTaskConfiguration.kt
+++ b/src/main/kotlin/com/coditory/gradle/integration/TestAllTaskConfiguration.kt
@@ -1,5 +1,6 @@
 package com.coditory.gradle.integration
 
+import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.INTEGRATION_TEST
 import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.TEST_ALL_TASK_NAME
 import com.coditory.gradle.integration.TestSkippingConditions.skipTestAll
 import org.gradle.api.Project
@@ -15,5 +16,6 @@ internal object TestAllTaskConfiguration {
         project.tasks.withType(Test::class.java).forEach {
             testAllTask.dependsOn(it.name)
         }
+        testAllTask.dependsOn(INTEGRATION_TEST)
     }
 }

--- a/src/main/kotlin/com/coditory/gradle/integration/TestSkippingConditions.kt
+++ b/src/main/kotlin/com/coditory/gradle/integration/TestSkippingConditions.kt
@@ -1,5 +1,7 @@
 package com.coditory.gradle.integration
 
+import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.INTEGRATION
+import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.INTEGRATION_TEST
 import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.SKIP_INTEGRATION_TEST_FLAG_NAME
 import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.SKIP_TEST_ALL_FLAG_NAME
 import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.SKIP_UNIT_TEST_FLAG_NAME
@@ -28,7 +30,11 @@ internal object TestSkippingConditions {
     }
 
     private fun hasSkipIntegrationTestFlag(project: Project): Boolean {
-        return hasPropertyFlag(project, SKIP_INTEGRATION_TEST_FLAG_NAME)
+        return hasPropertyFlag(project, SKIP_INTEGRATION_TEST_FLAG_NAME) || hasExcludeIntegrationTestTaskParam(project)
+    }
+
+    private fun hasExcludeIntegrationTestTaskParam(project: Project): Boolean {
+        return hasExcludedTask(project, INTEGRATION_TEST) || hasExcludedTask(project, INTEGRATION)
     }
 
     private fun hasPropertyFlag(project: Project, name: String): Boolean {
@@ -37,5 +43,9 @@ internal object TestSkippingConditions {
             return value == null || !value.toString().equals("false", true)
         }
         return false
+    }
+
+    private fun hasExcludedTask(project: Project, name: String): Boolean {
+        return project.gradle.startParameter.excludedTaskNames.contains(name)
     }
 }

--- a/src/test/kotlin/com/coditory/gradle/integration/JacocoConfigurationTest.kt
+++ b/src/test/kotlin/com/coditory/gradle/integration/JacocoConfigurationTest.kt
@@ -22,7 +22,7 @@ class JacocoConfigurationTest {
         assertThat(executionData.asPath).isEqualTo(
             project.toBuildPath(
                 "jacoco/test.exec",
-                "jacoco/integrationTest.exec",
+                "jacoco/integration.exec",
             ),
         )
     }

--- a/src/test/kotlin/com/coditory/gradle/integration/TestAllTaskConfigurationTest.kt
+++ b/src/test/kotlin/com/coditory/gradle/integration/TestAllTaskConfigurationTest.kt
@@ -1,5 +1,6 @@
 package com.coditory.gradle.integration
 
+import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.INTEGRATION
 import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.INTEGRATION_TEST
 import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.TEST_ALL_TASK_NAME
 import com.coditory.gradle.integration.base.TestProjectBuilder.Companion.createProject
@@ -16,7 +17,7 @@ class TestAllTaskConfigurationTest {
     @Test
     fun `should configure testAll task`() {
         val task = getTestAllTask()
-        assertThat(task.dependsOn).isEqualTo(setOf(TEST_TASK_NAME, INTEGRATION_TEST))
+        assertThat(task.dependsOn).isEqualTo(setOf(TEST_TASK_NAME, INTEGRATION, INTEGRATION_TEST))
         assertThat(task.description).isEqualTo("Runs all test suites.")
         assertThat(task.group).isEqualTo(VERIFICATION_GROUP)
         assertThat(task.enabled).isEqualTo(true)

--- a/src/test/kotlin/com/coditory/gradle/integration/TestTaskConfigurationTest.kt
+++ b/src/test/kotlin/com/coditory/gradle/integration/TestTaskConfigurationTest.kt
@@ -1,5 +1,6 @@
 package com.coditory.gradle.integration
 
+import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.INTEGRATION
 import com.coditory.gradle.integration.IntegrationTestPlugin.Companion.INTEGRATION_TEST
 import com.coditory.gradle.integration.base.TestProjectBuilder.Companion.createProject
 import com.coditory.gradle.integration.base.toBuildPath
@@ -20,8 +21,8 @@ class TestTaskConfigurationTest {
     fun `should configure integration source sets`() {
         val sourceSet = getSourceSet()
         assertThat(sourceSet).isNotNull
-        assertThat(sourceSet.output.classesDirs.asPath).isEqualTo(project.toBuildPath("classes/java/integrationTest"))
-        assertThat(sourceSet.output.resourcesDir.toString()).isEqualTo(project.toBuildPath("resources/integrationTest"))
+        assertThat(sourceSet.output.classesDirs.asPath).isEqualTo(project.toBuildPath("classes/java/integration"))
+        assertThat(sourceSet.output.resourcesDir.toString()).isEqualTo(project.toBuildPath("resources/integration"))
         // TODO: Fix it. Tried it all. It's failing with Could not find org.gradle.internal.impldep.org.junit.jupiter:junit-jupiter:5.8.2
         // Tried: adding repositories to test project, defining tests to use junit platform etc - did not help...
         // assertThat(sourceSet.runtimeClasspath.asPath)
@@ -42,7 +43,7 @@ class TestTaskConfigurationTest {
         val integrationSourceSet = getSourceSet()
         val task = getTestTask()
         assertThat(task.testClassesDirs).isNotNull
-        assertThat(task.description).isEqualTo("Runs the integration test suite.")
+        assertThat(task.description).isEqualTo("Runs the integration suite.")
         assertThat(task.group).isEqualTo(VERIFICATION_GROUP)
         assertThat(task.testClassesDirs).isEqualTo(integrationSourceSet.output.classesDirs)
         assertThat(task.classpath).isEqualTo(integrationSourceSet.runtimeClasspath)
@@ -58,13 +59,13 @@ class TestTaskConfigurationTest {
     }
 
     private fun getTestTask(): TestTask {
-        return project.tasks.getByName(INTEGRATION_TEST) as TestTask
+        return project.tasks.getByName(INTEGRATION) as TestTask
     }
 
     @Suppress("UnstableApiUsage")
     private fun getSourceSet(project: Project = this.project): SourceSet {
         return project.extensions.getByType(TestingExtension::class.java).suites
-            .getByName(INTEGRATION_TEST)
+            .getByName(INTEGRATION)
             .let { it as JvmTestSuite }
             .sources
     }

--- a/src/test/kotlin/com/coditory/gradle/integration/acceptance/CommandLineAcceptanceTest.kt
+++ b/src/test/kotlin/com/coditory/gradle/integration/acceptance/CommandLineAcceptanceTest.kt
@@ -46,7 +46,7 @@ class CommandLineAcceptanceTest {
                 }
                 """,
             ).withFile(
-                "src/integrationTest/java/TestIntgSpec.java",
+                "src/integration/java/TestIntgSpec.java",
                 """
                 $commonImports
 
@@ -84,7 +84,16 @@ class CommandLineAcceptanceTest {
         val result = runGradle(project, listOf("check"), gradleVersion)
         // then
         assertThat(result.task(":test")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(result.task(":integrationTest")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":integration")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @ParameterizedTest(name = "should run integration tests on integrationTest command for gradle {0}")
+    @ValueSource(strings = [GRADLE_MAX_SUPPORTED_VERSION, GRADLE_MIN_SUPPORTED_VERSION])
+    fun `should run integration tests on integrationTest command`(gradleVersion: String?) {
+        // when
+        val result = runGradle(project, listOf("integrationTest"), gradleVersion)
+        // then
+        assertThat(result.task(":integration")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     }
 
     @Test
@@ -93,7 +102,7 @@ class CommandLineAcceptanceTest {
         val result = runGradle(project, listOf("test"))
         // then
         assertThat(result.task(":test")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(result.task(":integrationTest")?.outcome).isNull()
+        assertThat(result.task(":integration")?.outcome).isNull()
     }
 
     @Test
@@ -102,7 +111,7 @@ class CommandLineAcceptanceTest {
         val result = runGradle(project, listOf("testAll"))
         // then
         assertThat(result.task(":test")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(result.task(":integrationTest")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":integration")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     }
 
     @Test
@@ -111,7 +120,7 @@ class CommandLineAcceptanceTest {
         val result = runGradle(project, listOf("check", "-x", "integrationTest"))
         // then
         assertThat(result.task(":test")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(result.task(":integrationTest")?.outcome).isNull()
+        assertThat(result.task(":integration")?.outcome).isEqualTo(TaskOutcome.SKIPPED)
     }
 
     @Test
@@ -120,7 +129,7 @@ class CommandLineAcceptanceTest {
         val result = runGradle(project, listOf("check", "-PskipIntegrationTest"))
         // then
         assertThat(result.task(":test")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(result.task(":integrationTest")?.outcome).isEqualTo(TaskOutcome.SKIPPED)
+        assertThat(result.task(":integration")?.outcome).isEqualTo(TaskOutcome.SKIPPED)
     }
 
     @Test
@@ -129,7 +138,7 @@ class CommandLineAcceptanceTest {
         val result = runGradle(project, listOf("check", "-PskipTest"))
         // then
         assertThat(result.task(":test")?.outcome).isEqualTo(TaskOutcome.SKIPPED)
-        assertThat(result.task(":integrationTest")?.outcome).isEqualTo(TaskOutcome.SKIPPED)
+        assertThat(result.task(":integration")?.outcome).isEqualTo(TaskOutcome.SKIPPED)
     }
 
     @Test
@@ -138,6 +147,6 @@ class CommandLineAcceptanceTest {
         val result = runGradle(project, listOf("check", "-PskipUnitTest"))
         // then
         assertThat(result.task(":test")?.outcome).isEqualTo(TaskOutcome.SKIPPED)
-        assertThat(result.task(":integrationTest")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":integration")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     }
 }

--- a/src/test/kotlin/com/coditory/gradle/integration/acceptance/JacocoBasedAcceptanceTest.kt
+++ b/src/test/kotlin/com/coditory/gradle/integration/acceptance/JacocoBasedAcceptanceTest.kt
@@ -65,7 +65,7 @@ class JacocoBasedAcceptanceTest {
                 }
                 """,
             ).withFile(
-                "src/integrationTest/java/TestIntgSpec.java",
+                "src/integration/java/TestIntgSpec.java",
                 """
                 $commonImports
 

--- a/src/test/kotlin/com/coditory/gradle/integration/acceptance/Junit5BasedAcceptanceTest.kt
+++ b/src/test/kotlin/com/coditory/gradle/integration/acceptance/Junit5BasedAcceptanceTest.kt
@@ -36,7 +36,7 @@ class Junit5BasedAcceptanceTest {
                     testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.0"
                     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.0"
                     // sample integration test dependency
-                    integrationTestImplementation "org.slf4j:slf4j-api:2.0.16"
+                    integrationImplementation "org.slf4j:slf4j-api:2.0.16"
                 }
 
                 tasks.withType(Test) {
@@ -79,7 +79,7 @@ class Junit5BasedAcceptanceTest {
                 }
                 """,
             ).withFile(
-                "src/integrationTest/java/ConstantValues.java",
+                "src/integration/java/ConstantValues.java",
                 """
                 public class ConstantValues {
                     public static final String MODULE = "integration";
@@ -100,7 +100,7 @@ class Junit5BasedAcceptanceTest {
                 }
                 """,
             ).withFile(
-                "src/integrationTest/java/TestIntgSpec.java",
+                "src/integration/java/TestIntgSpec.java",
                 """
                 $commonImports
 
@@ -163,7 +163,7 @@ class Junit5BasedAcceptanceTest {
             .withFile("src/main/resources/c.txt", "main-c")
             .withFile("src/test/resources/b.txt", "test-b")
             .withFile("src/test/resources/c.txt", "test-c")
-            .withFile("src/integrationTest/resources/c.txt", "integration-c")
+            .withFile("src/integration/resources/c.txt", "integration-c")
             .build()
     }
 
@@ -174,6 +174,6 @@ class Junit5BasedAcceptanceTest {
         val result = runGradle(project, listOf("check"), gradleVersion)
         // then
         assertThat(result.task(":test")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(result.task(":integrationTest")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":integration")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     }
 }

--- a/src/test/kotlin/com/coditory/gradle/integration/acceptance/KotlinInternalScopeAcceptanceTest.kt
+++ b/src/test/kotlin/com/coditory/gradle/integration/acceptance/KotlinInternalScopeAcceptanceTest.kt
@@ -37,7 +37,7 @@ class KotlinInternalScopeAcceptanceTest {
                     testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.0")
                     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.0")
                     // sample integration test dependency
-                    integrationTestImplementation("org.slf4j:slf4j-api:2.0.16")
+                    integrationImplementation("org.slf4j:slf4j-api:2.0.16")
                 }
 
                 tasks.withType<Test> {
@@ -63,7 +63,7 @@ class KotlinInternalScopeAcceptanceTest {
                 }
                 """,
             ).withFile(
-                "src/integrationTest/kotlin/TestIntgSpec.kt",
+                "src/integration/kotlin/TestIntgSpec.kt",
                 """
                 $commonImports
 

--- a/src/test/kotlin/com/coditory/gradle/integration/acceptance/LombokAcceptanceTest.kt
+++ b/src/test/kotlin/com/coditory/gradle/integration/acceptance/LombokAcceptanceTest.kt
@@ -70,7 +70,7 @@ class LombokAcceptanceTest {
                 }
                 """,
             ).withFile(
-                "src/integrationTest/java/IntgValueExample.java",
+                "src/integration/java/IntgValueExample.java",
                 """
                 import lombok.Value;
 
@@ -80,7 +80,7 @@ class LombokAcceptanceTest {
                 }
                 """,
             ).withFile(
-                "src/integrationTest/java/TestIntgSpec.java",
+                "src/integration/java/TestIntgSpec.java",
                 """
                 $commonImports
 

--- a/src/test/kotlin/com/coditory/gradle/integration/acceptance/SpockBasedAcceptanceTest.kt
+++ b/src/test/kotlin/com/coditory/gradle/integration/acceptance/SpockBasedAcceptanceTest.kt
@@ -26,7 +26,7 @@ class SpockBasedAcceptanceTest {
                 dependencies {
                     testImplementation "org.spockframework:spock-core:2.4-M4-groovy-4.0"
                     // sample integration test dependency
-                    integrationTestImplementation "org.slf4j:slf4j-api:2.0.16"
+                    integrationImplementation "org.slf4j:slf4j-api:2.0.16"
                 }
 
                 tasks.withType(Test) {
@@ -53,7 +53,7 @@ class SpockBasedAcceptanceTest {
                 }
                 """,
             ).withFile(
-                "src/integrationTest/groovy/ConstantValues.groovy",
+                "src/integration/groovy/ConstantValues.groovy",
                 """
                 class ConstantValues {
                     static final String MODULE = "integration"
@@ -74,7 +74,7 @@ class SpockBasedAcceptanceTest {
                 }
                 """,
             ).withFile(
-                "src/integrationTest/groovy/TestIntgSpec.groovy",
+                "src/integration/groovy/TestIntgSpec.groovy",
                 """
                 import spock.lang.Specification
                 import static ClasspathFileReader.readFile
@@ -134,7 +134,7 @@ class SpockBasedAcceptanceTest {
             .withFile("src/main/resources/c.txt", "main-c")
             .withFile("src/test/resources/b.txt", "test-b")
             .withFile("src/test/resources/c.txt", "test-c")
-            .withFile("src/integrationTest/resources/c.txt", "integration-c")
+            .withFile("src/integration/resources/c.txt", "integration-c")
             .build()
 
     @ParameterizedTest(name = "should run unit tests and integration tests on check command for gradle {0}")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->

## Changes

Revert source name from `src/integrationTest` back to `src/integration`, so there is less confusion.

Details: https://github.com/coditory/gradle-integration-test-plugin/issues/127#issuecomment-2409068604

## Checklist

- [x] I have tested that there is no similar [pull request](../pulls) already submitted.
- [x] I have read [contributing.md](/.github/CONTRIBUTING.md) and applied to the rules.
- [x] I have updated the documentation if feature was added or changed.
- [x] I have unit tested code changes and performed a self-review.
- [x] I have manually tested change locally.
