### PR TITLE
Fix source set inheritance

### DIFF
--- a/src/test/kotlin/com/coditory/gradle/integration/acceptance/Junit5BasedAcceptanceTest.kt
+++ b/src/test/kotlin/com/coditory/gradle/integration/acceptance/Junit5BasedAcceptanceTest.kt
@@ -19,6 +19,7 @@ class Junit5BasedAcceptanceTest {
             import org.junit.jupiter.api.Test;
 
             import static org.junit.jupiter.api.Assertions.assertEquals;
+            import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
             import static base.ClasspathFileReader.readFile;
             """.trimIndent()
         return project("sample-project")
@@ -33,10 +34,12 @@ class Junit5BasedAcceptanceTest {
                 }
 
                 dependencies {
+                    implementation platform("org.springframework.boot:spring-boot-dependencies:3.3.3")
                     testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.0"
                     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.0"
                     // sample integration test dependency
                     integrationImplementation "org.slf4j:slf4j-api:2.0.16"
+                    integrationImplementation "org.springframework.boot:spring-boot-starter-test"
                 }
 
                 tasks.withType(Test) {
@@ -116,7 +119,7 @@ class Junit5BasedAcceptanceTest {
                     }
 
                     @Test
-                    public void shouldReadCTxtFileFromTest() {
+                    public void shouldReadCTxtFileFromIntegration() {
                         assertEquals("integration-c", readFile("c.txt"));
                     }
 
@@ -128,6 +131,13 @@ class Junit5BasedAcceptanceTest {
                     @Test
                     public void shouldReadConstantValueFromMainModule() {
                         assertEquals("main", MainConstantValues.MODULE);
+                    }
+
+                    @Test
+                    void shouldResolveDependencyFromBom() {
+                        assertDoesNotThrow(
+                            () -> Class.forName("org.springframework.test.context.ContextConfiguration")
+                        );
                     }
                 }
                 """,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->

## Changes

Since 2.0.0, BOM dependencies are not propagated from `main` and `test` source sets into the `integration` source set. As a result, the following buildscript:
```kotlin
plugins {
    java
    id("com.coditory.integration-test") version "2.0.1"
}

dependencies {
    implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.3"))
    integrationImplementation("org.springframework.boot:spring-boot-starter-test")
}
```
won't be able to resolve the `spring-boot-starter-test` dependency:
```
Could not find org.springframework.boot:spring-boot-starter-test:.
Required by:
    root project :
```

It is because the plugin only adds the `compileClasspath` and `runtimeClasspath` file collections:
```kotlin
it.sources.compileClasspath += testSourceSet.output + mainSourceSet.output + testSourceSet.compileClasspath
it.sources.runtimeClasspath += testSourceSet.output + mainSourceSet.output + testSourceSet.runtimeClasspath
```

It works for normal dependencies, but in case of `platform(...)` dependencies there are no files to be resolved to `FileCollection`. Only version constraints are imported from the BOM.

To fix that issue, I've set up the following configuration inheritance:
* `integrationCompileClasspath` extends `testCompileClasspath`
* `integrationRuntimeClasspath` extends `testRuntimeClasspath`
* `integrationAnnotationProcessor` extends `testAnnotationProcessor`

## Checklist

- [x] I have tested that there is no similar [pull request](../pulls) already submitted.
- [x] I have read [contributing.md](/.github/CONTRIBUTING.md) and applied to the rules.
- [ ] I have updated the documentation if feature was added or changed.
- [x] I have unit tested code changes and performed a self-review.
- [x] I have manually tested change locally.
