### PR TITLE
Support jacoco report task run separately

### DIFF
--- a/src/integration/kotlin/com/coditory/gradle/integration/CommandLineTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/CommandLineTest.kt
@@ -6,6 +6,7 @@ import com.coditory.gradle.integration.base.TestProject
 import com.coditory.gradle.integration.base.TestProjectBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AutoClose
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -79,6 +80,12 @@ class CommandLineTest {
                 )
                 .build()
         }
+    }
+
+    @AfterEach
+    fun cleanProjects() {
+        project.clean()
+        failingProject.clean()
     }
 
     @ParameterizedTest(name = "should run unit tests and integration tests on check command for gradle {0}")

--- a/src/integration/kotlin/com/coditory/gradle/integration/JUnitBasicTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/JUnitBasicTest.kt
@@ -6,6 +6,7 @@ import com.coditory.gradle.integration.base.TestProject
 import com.coditory.gradle.integration.base.TestProjectBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AutoClose
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -78,6 +79,12 @@ class JUnitBasicTest {
                 )
                 .build()
         }
+    }
+
+    @AfterEach
+    fun cleanProjects() {
+        project.clean()
+        failingProject.clean()
     }
 
     @ParameterizedTest(name = "should pass unit tests and integration tests on check command for gradle {0}")

--- a/src/integration/kotlin/com/coditory/gradle/integration/JUnitClasspathTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/JUnitClasspathTest.kt
@@ -6,6 +6,7 @@ import com.coditory.gradle.integration.base.TestProject
 import com.coditory.gradle.integration.base.TestProjectBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AutoClose
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -193,6 +194,11 @@ class JUnitClasspathTest {
             }
             return builder.build()
         }
+    }
+
+    @AfterEach
+    fun cleanProject() {
+        project.clean()
     }
 
     @ParameterizedTest(name = "should read files from classpath for gradle {0}")

--- a/src/integration/kotlin/com/coditory/gradle/integration/KotestBasicTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/KotestBasicTest.kt
@@ -6,6 +6,7 @@ import com.coditory.gradle.integration.base.TestProject
 import com.coditory.gradle.integration.base.TestProjectBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AutoClose
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -78,6 +79,12 @@ class KotestBasicTest {
                 )
                 .build()
         }
+    }
+
+    @AfterEach
+    fun cleanProjects() {
+        project.clean()
+        failingProject.clean()
     }
 
     @ParameterizedTest(name = "should pass unit tests and integration tests on check command for gradle {0}")

--- a/src/integration/kotlin/com/coditory/gradle/integration/KotestClasspathTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/KotestClasspathTest.kt
@@ -6,6 +6,7 @@ import com.coditory.gradle.integration.base.TestProject
 import com.coditory.gradle.integration.base.TestProjectBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AutoClose
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -163,6 +164,11 @@ class KotestClasspathTest {
             }
             return builder.build()
         }
+    }
+
+    @AfterEach
+    fun cleanProject() {
+        project.clean()
     }
 
     @ParameterizedTest(name = "should read files from classpath for gradle {0}")

--- a/src/integration/kotlin/com/coditory/gradle/integration/KotlinInternalScopeTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/KotlinInternalScopeTest.kt
@@ -5,6 +5,7 @@ import com.coditory.gradle.integration.base.GradleTestVersions.GRADLE_MIN_SUPPOR
 import com.coditory.gradle.integration.base.TestProjectBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AutoClose
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -94,6 +95,11 @@ class KotlinInternalScopeTest {
                 """,
             )
             .build()
+    }
+
+    @AfterEach
+    fun cleanProject() {
+        project.clean()
     }
 
     @ParameterizedTest(name = "should make internal scope visible in integration tests for gradle {0}")

--- a/src/integration/kotlin/com/coditory/gradle/integration/LazyTaskRegisteringTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/LazyTaskRegisteringTest.kt
@@ -2,6 +2,7 @@ package com.coditory.gradle.integration
 
 import com.coditory.gradle.integration.base.TestProjectBuilder
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AutoClose
 import org.junit.jupiter.api.Test
 
@@ -34,6 +35,11 @@ class LazyTaskRegisteringTest {
                     """,
             )
             .build()
+    }
+
+    @AfterEach
+    fun cleanProject() {
+        project.clean()
     }
 
     @Test

--- a/src/integration/kotlin/com/coditory/gradle/integration/LombokTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/LombokTest.kt
@@ -5,6 +5,7 @@ import com.coditory.gradle.integration.base.GradleTestVersions.GRADLE_MIN_SUPPOR
 import com.coditory.gradle.integration.base.TestProjectBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AutoClose
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -123,6 +124,11 @@ class LombokTest {
                 """,
             )
             .build()
+    }
+
+    @AfterEach
+    fun cleanProject() {
+        project.clean()
     }
 
     @ParameterizedTest(name = "should run unit tests and integration tests on check command for gradle {0}")

--- a/src/integration/kotlin/com/coditory/gradle/integration/PlatformDependencyTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/PlatformDependencyTest.kt
@@ -5,6 +5,7 @@ import com.coditory.gradle.integration.base.GradleTestVersions.GRADLE_MIN_SUPPOR
 import com.coditory.gradle.integration.base.TestProjectBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AutoClose
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -54,6 +55,11 @@ class PlatformDependencyTest {
                 """,
             )
             .build()
+    }
+
+    @AfterEach
+    fun cleanProject() {
+        project.clean()
     }
 
     @ParameterizedTest(name = "should use dependency version from platform dependency for gradle {0}")

--- a/src/integration/kotlin/com/coditory/gradle/integration/SpockBasicTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/SpockBasicTest.kt
@@ -7,6 +7,7 @@ import com.coditory.gradle.integration.base.TestProjectBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AutoClose
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -75,6 +76,12 @@ class SpockBasicTest {
                     """,
                 ).build()
         }
+    }
+
+    @AfterEach
+    fun cleanProjects() {
+        project.clean()
+        failingProject.clean()
     }
 
     @ParameterizedTest(name = "should pass unit tests and integration tests on check command for gradle {0}")

--- a/src/integration/kotlin/com/coditory/gradle/integration/SpockClasspathTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/SpockClasspathTest.kt
@@ -6,6 +6,7 @@ import com.coditory.gradle.integration.base.TestProject
 import com.coditory.gradle.integration.base.TestProjectBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AutoClose
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -164,6 +165,11 @@ class SpockClasspathTest {
             }
             return builder.build()
         }
+    }
+
+    @AfterEach
+    fun cleanProject() {
+        project.clean()
     }
 
     @ParameterizedTest(name = "should read files from classpath for gradle {0}")

--- a/src/main/kotlin/com/coditory/gradle/integration/JacocoTaskConfiguration.kt
+++ b/src/main/kotlin/com/coditory/gradle/integration/JacocoTaskConfiguration.kt
@@ -7,21 +7,24 @@ import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 import org.gradle.testing.jacoco.tasks.JacocoReport
 
 internal object JacocoTaskConfiguration {
+    private const val JACOCO_PLUGIN = "jacoco"
+    private const val JACOCO_REPORT_TASK = "jacocoTestReport"
+
     fun apply(project: Project) {
-        if (!project.pluginManager.hasPlugin("jacoco")) return
+        if (!project.pluginManager.hasPlugin(JACOCO_PLUGIN)) return
         project.tasks.withType(JacocoCoverageVerification::class.java).configureEach { task ->
             task.mustRunAfter(INTEGRATION)
         }
         project.tasks.withType(JacocoReport::class.java).configureEach { task ->
             task.mustRunAfter(INTEGRATION)
         }
-        // execute only if integration test and jacoco are on the execution path
+        // execute only if integration tests or jacocoTestReport are on the execution path
         // to preserve lazy task configuration
         project.gradle.taskGraph.whenReady {
             val names = project.gradle.taskGraph.allTasks.map { it.name }
-            if (names.contains("jacocoTestReport") && names.contains(INTEGRATION)) {
+            if (names.contains(JACOCO_REPORT_TASK) || names.contains(INTEGRATION)) {
                 project.tasks.withType(JacocoReport::class.java)
-                    .named("jacocoTestReport") { reportTask ->
+                    .named(JACOCO_REPORT_TASK) { reportTask ->
                         val jacocoTaskExtension =
                             project.tasks.getByName(INTEGRATION).extensions.getByType(JacocoTaskExtension::class.java)
                         val dstFile = jacocoTaskExtension.destinationFile?.path

--- a/src/test/kotlin/com/coditory/gradle/integration/base/TestProject.kt
+++ b/src/test/kotlin/com/coditory/gradle/integration/base/TestProject.kt
@@ -29,9 +29,11 @@ class TestProject(private val project: Project) : Project by project {
         this.projectDir.deleteRecursively()
     }
 
-    private fun gradleRunner(project: Project, arguments: List<String>, gradleVersion: String? = null): GradleRunner {
-        // clean is required so tasks are not cached
-        val args = if (arguments.contains("clean")) arguments else listOf("clean") + arguments
+    fun clean() {
+        this.runGradle(listOf("clean"))
+    }
+
+    private fun gradleRunner(project: Project, args: List<String>, gradleVersion: String? = null): GradleRunner {
         val builder = GradleRunner.create()
             .withProjectDir(project.projectDir)
             .withArguments(args)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->

## Changes

<!-- Shortly describe what you want to accomplish with this PR. -->
<!-- Add a link to the issue if available. -->
In v2.2.0 when `jacocoTestReport` is run separately from check or test tasks the report does not aggregate coverage integration tests. This PR fixes it.  

Issue: https://github.com/coditory/gradle-integration-test-plugin/issues/159

## Checklist

- [x] I have tested that there is no similar [pull request](../pulls) already submitted.
- [x] I have read [contributing.md](/.github/CONTRIBUTING.md) and applied to the rules.
- [x] I have updated the documentation if feature was added or changed.
- [x] I have unit tested code changes and performed a self-review.
- [x] I have manually tested change locally.
