### PR TITLE
Make configuration inheritance consistent with Gradle

### DIFF
--- a/src/integration/kotlin/com/coditory/gradle/integration/ConfigurationInheritanceTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/ConfigurationInheritanceTest.kt
@@ -25,11 +25,6 @@ class ConfigurationInheritanceTest {
                     mavenCentral()
                 }
 
-                dependencies {
-                    testImplementation("org.junit.jupiter:junit-jupiter-api:${Versions.junit}")
-                    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${Versions.junit}")
-                }
-
                 testing {
                     suites {
                         register<JvmTestSuite>("customTest")
@@ -40,13 +35,12 @@ class ConfigurationInheritanceTest {
                     extendsFrom(configurations.integrationImplementation.get())
                 }
                 val customTestRuntimeOnly by configurations.getting {
-
                     extendsFrom(configurations.integrationRuntimeOnly.get())
                 }
 
                 dependencies {
                     testImplementation("org.junit.jupiter:junit-jupiter:${Versions.junit}")
-                    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+                    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${Versions.junit}")
                     // sample dependency
                     implementation("com.google.code.gson:gson:${Versions.gson}")
                 }

--- a/src/integration/kotlin/com/coditory/gradle/integration/ConfigurationInheritanceTest.kt
+++ b/src/integration/kotlin/com/coditory/gradle/integration/ConfigurationInheritanceTest.kt
@@ -1,0 +1,92 @@
+package com.coditory.gradle.integration
+
+import com.coditory.gradle.integration.base.GradleTestVersions.GRADLE_MAX_SUPPORTED_VERSION
+import com.coditory.gradle.integration.base.GradleTestVersions.GRADLE_MIN_SUPPORTED_VERSION
+import com.coditory.gradle.integration.base.TestProjectBuilder
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.AutoClose
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class ConfigurationInheritanceTest {
+    companion object {
+        @AutoClose
+        private val project = TestProjectBuilder
+            .project("project-${ConfigurationInheritanceTest::class.simpleName}")
+            .withBuildGradleKts(
+                """
+                plugins {
+                    id("com.coditory.integration-test")
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    testImplementation("org.junit.jupiter:junit-jupiter-api:${Versions.junit}")
+                    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${Versions.junit}")
+                }
+
+                testing {
+                    suites {
+                        register<JvmTestSuite>("customTest")
+                    }
+                }
+
+                val customTestImplementation by configurations.getting {
+                    extendsFrom(configurations.integrationImplementation.get())
+                }
+                val customTestRuntimeOnly by configurations.getting {
+
+                    extendsFrom(configurations.integrationRuntimeOnly.get())
+                }
+
+                dependencies {
+                    testImplementation("org.junit.jupiter:junit-jupiter:${Versions.junit}")
+                    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+                    // sample dependency
+                    implementation("com.google.code.gson:gson:${Versions.gson}")
+                }
+
+                tasks.withType<Test>().configureEach {
+                    useJUnitPlatform()
+                    testLogging {
+                        events("passed", "failed", "skipped")
+                        setExceptionFormat("full")
+                    }
+                }
+                """,
+            ).withFile(
+                "src/customTest/java/TestSpec.java",
+                """
+                import org.junit.jupiter.api.Test;
+                import com.google.gson.Gson;
+
+                public class TestSpec {
+                    @Test
+                    void shouldResolveCompileDependencyFromMainConfig() {
+                        // Gson class import is the actual test
+                    }
+                }
+                """,
+            )
+            .build()
+    }
+
+    @AfterEach
+    fun cleanProject() {
+        project.clean()
+    }
+
+    @ParameterizedTest(name = "should resolve compile dependencies in custom test suite for gradle {0}")
+    @ValueSource(strings = [GRADLE_MAX_SUPPORTED_VERSION, GRADLE_MIN_SUPPORTED_VERSION])
+    fun `should resolve compile dependencies in custom test suite`(gradleVersion: String?) {
+        // when
+        val result = project.runGradle(listOf("customTest"), gradleVersion)
+        // then
+        assertThat(result.task(":customTest")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+}

--- a/src/main/kotlin/com/coditory/gradle/integration/TestSuitesConfiguration.kt
+++ b/src/main/kotlin/com/coditory/gradle/integration/TestSuitesConfiguration.kt
@@ -57,11 +57,14 @@ internal object TestSuitesConfiguration {
         val testSourceSet = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME)
         val integrationSourceSet = testSuite.sources
 
-        project.configurations.getByName(integrationSourceSet.compileClasspathConfigurationName)
-            .extendsFrom(project.configurations.getByName(testSourceSet.compileClasspathConfigurationName))
+        project.configurations.getByName(integrationSourceSet.implementationConfigurationName)
+            .extendsFrom(project.configurations.getByName(testSourceSet.implementationConfigurationName))
 
         project.configurations.getByName(integrationSourceSet.runtimeOnlyConfigurationName)
-            .extendsFrom(project.configurations.getByName(testSourceSet.runtimeClasspathConfigurationName))
+            .extendsFrom(project.configurations.getByName(testSourceSet.runtimeOnlyConfigurationName))
+
+        project.configurations.getByName(integrationSourceSet.compileOnlyConfigurationName)
+            .extendsFrom(project.configurations.getByName(testSourceSet.compileOnlyConfigurationName))
 
         project.configurations.getByName(integrationSourceSet.annotationProcessorConfigurationName)
             .extendsFrom(project.configurations.getByName(testSourceSet.annotationProcessorConfigurationName))


### PR DESCRIPTION
## Changes

<!-- Shortly describe what you want to accomplish with this PR. -->
<!-- Add a link to the issue if available. -->

In my project I have a custom test suite that is supposed to inherit dependencies from the integration test classpath.
It is achieved by extending configurations used by the new suite from ones used by integration tests: 
```kotlin
configurations {
    named("myTestImplementation") {
        extendsFrom(getByName("integrationImplementation"))
    }
    named("myTestRuntimeOnly") {
        extendsFrom(getByName("integrationRuntimeOnly"))
    }
    named("myTestAnnotationProcessor") {
        extendsFrom(getByName("integrationAnnotationProcessor"))
    }
    named("myTestCompileOnly") {
        extendsFrom(getByName("integrationCompileOnly"))
    }
}
```
It used to work in version 1.x of this plugin but doesn't work anymore in 2.x. 
After improvements in #144 I could achieve what I need extending from `integrationCompileClasspath` configuration (which extends directly from `testCompileClasspath` and indirectly from `testImplementation` and `testCompileOnly`). My code currently fails because `integrationImplementation` does not depend on `testImplementation`.
Why I think current approach may be not optimal:
* Gradle extends `testImplementation` configuration in [example setup](https://docs.gradle.org/current/userguide/java_testing.html#sec:configuring_java_integration_tests) for integration tests:
* built-in test source-set configurations [extend](https://github.com/gradle/gradle/blob/d4571c1b57bbdfbc075dcc03f64f20680a7feb55/platforms/jvm/plugins-java/src/main/java/org/gradle/api/plugins/JavaPlugin.java#L381-L382) from `implementation` and `runtimeOnly` configs (from main source-set) and not `compileClasspath`
* Gradle extends `implementation` config in multiple samples, e.g. [here](https://github.com/gradle/gradle/blob/d4571c1b57bbdfbc075dcc03f64f20680a7feb55/platforms/documentation/docs/src/samples/build-organization/gradle-plugin/kotlin/greeting-plugin/build.gradle.kts#L30)

Not sure if `compileOnly` and `annotationProcessor` configurations should be extended. Gradle does do it in its `test` source-set or integration tests example, which IMHO makes some sense (those dependencies should only be needed to compile the source-set, not to use it). I left it as is to avoid potential breaking changes.

Old behavior:
* `integrationCompileClasspath` extends from `testCompileClasspath`
* `integrationRuntimeOnly extends from `testRuntimeClasspath`

New behavior:
* `integrationImplementation` extends from `testImplementation`
* `integrationRuntimeOnly extends from `testRuntimeOnly`

I think new behavior is more consistent with Gradle recommendations, which should cause less confusion when extending integration test configurations. At the same time I think this change should not break existing setups, because `integrationCompileClasspath` already extends `integrationImplementation` and `integrationCompileOnly`. Runtime classpath should also not be affected because it's implementation+runtimeOnly.

## Checklist

- [x] I have tested that there is no similar [pull request](../pulls) already submitted.
- [x] I have read [contributing.md](/.github/CONTRIBUTING.md) and applied to the rules. (I think you mean DEVELOPMENT.md, CONTRIBUTING.md does not exist)
- [ ] I have updated the documentation if feature was added or changed.
- [x] I have unit tested code changes and performed a self-review.
- [x] I have manually tested change locally.
